### PR TITLE
Fix: Change 'as' to 'AS' for proper Dockerfile casing

### DIFF
--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:18-alpine as builder
+FROM node:18-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR fixes the casing of the 'as' keyword to 'AS' in the Dockerfile.frontend to resolve a warning during the build process. This change ensures compatibility, particularly on Linux, where the lowercase 'as' caused issues.