### PR TITLE
feat: Add request context to university domain

### DIFF
--- a/api/handlers/auth.go
+++ b/api/handlers/auth.go
@@ -412,7 +412,7 @@ func (h *AuthHandler) GetCurrentUser(c *gin.Context) {
 	var universityResponse *dto.UniversityResponse
 	// Check if UniversityID is valid before attempting fetch
 	if user.UniversityID != uuid.Nil {
-		universityResponse, err = h.universityService.Get(user.UniversityID)
+		universityResponse, err = h.universityService.Get(ctx, user.UniversityID)
 		if err != nil {
 			h.logger.Warn("Failed to fetch university details for user (continuing)",
 				zap.String("userID", user.ID.String()),

--- a/api/services/admin_user.go
+++ b/api/services/admin_user.go
@@ -46,7 +46,7 @@ func NewAdminUserService(
 }
 
 func (s *adminUserService) Create(ctx context.Context, req *dto.AdminCreateUserRequest) (*dto.AdminUserResponse, error) {
-	if _, err := s.universityService.Get(req.UniversityID); err != nil {
+	if _, err := s.universityService.Get(ctx, req.UniversityID); err != nil {
 		if errors.Is(err, errors.ErrNotFound) {
 			return nil, errors.NewValidationError("invalid university_id")
 		}
@@ -144,7 +144,7 @@ func (s *adminUserService) Update(ctx context.Context, id uuid.UUID, req *dto.Ad
 	}
 
 	if req.UniversityID != uuid.Nil && req.UniversityID != user.UniversityID {
-		if _, err := s.universityService.Get(req.UniversityID); err != nil {
+		if _, err := s.universityService.Get(ctx, req.UniversityID); err != nil {
 			if errors.Is(err, errors.ErrNotFound) {
 				return nil, errors.NewValidationError("invalid university_id")
 			}

--- a/api/services/auth_test.go
+++ b/api/services/auth_test.go
@@ -164,8 +164,8 @@ type MockUniversityService struct {
 	mock.Mock
 }
 
-func (m *MockUniversityService) Get(id uuid.UUID) (*dto.UniversityResponse, error) {
-	args := m.Called(id)
+func (m *MockUniversityService) Get(ctx context.Context, id uuid.UUID) (*dto.UniversityResponse, error) {
+	args := m.Called(ctx, id)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -173,19 +173,19 @@ func (m *MockUniversityService) Get(id uuid.UUID) (*dto.UniversityResponse, erro
 }
 
 // Implement other methods if needed by tests, otherwise leave empty or panic
-func (m *MockUniversityService) Create(req *dto.CreateUniversityRequest) (*dto.UniversityResponse, error) {
+func (m *MockUniversityService) Create(ctx context.Context, req *dto.CreateUniversityRequest) (*dto.UniversityResponse, error) {
 	panic("Create not implemented in mock")
 }
-func (m *MockUniversityService) GetAll() ([]dto.UniversityResponse, error) {
+func (m *MockUniversityService) GetAll(ctx context.Context) ([]dto.UniversityResponse, error) {
 	panic("GetAll not implemented in mock")
 }
-func (m *MockUniversityService) Update(id uuid.UUID, req *dto.UpdateUniversityRequest) (*dto.UniversityResponse, error) {
+func (m *MockUniversityService) Update(ctx context.Context, id uuid.UUID, req *dto.UpdateUniversityRequest) (*dto.UniversityResponse, error) {
 	panic("Update not implemented in mock")
 }
-func (m *MockUniversityService) ExistsByName(nameEn, nameFa string) (bool, error) {
+func (m *MockUniversityService) ExistsByName(ctx context.Context, nameEn, nameFa string) (bool, error) {
 	panic("ExistsByName not implemented in mock")
 }
-func (m *MockUniversityService) Delete(id uuid.UUID) error {
+func (m *MockUniversityService) Delete(ctx context.Context, id uuid.UUID) error {
 	panic("Delete not implemented in mock")
 }
 

--- a/api/services/course.go
+++ b/api/services/course.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"fmt"
 	"github.com/armanjr/termustat/api/dto"
 	"github.com/armanjr/termustat/api/errors"
@@ -52,7 +53,7 @@ func NewCourseService(
 }
 
 func (s *courseService) Create(dto dto.CreateCourseDTO) (*dto.CourseResponse, error) {
-	if _, err := s.universityService.Get(dto.UniversityID); err != nil {
+	if _, err := s.universityService.Get(context.Background(), dto.UniversityID); err != nil {
 		return nil, err
 	}
 
@@ -195,7 +196,7 @@ func (s *courseService) Update(id uuid.UUID, dto dto.UpdateCourseDTO) (*dto.Cour
 		}
 	}
 
-	if _, err := s.universityService.Get(dto.UniversityID); err != nil {
+	if _, err := s.universityService.Get(context.Background(), dto.UniversityID); err != nil {
 		return nil, err
 	}
 
@@ -280,7 +281,7 @@ func (s *courseService) BatchCreate(dtos []dto.CreateCourseDTO) ([]*dto.CourseRe
 	semesterID := dtos[0].SemesterID
 
 	// Validate university exists
-	if _, err := s.universityService.Get(universityID); err != nil {
+	if _, err := s.universityService.Get(context.Background(), universityID); err != nil {
 		return nil, err
 	}
 
@@ -557,7 +558,7 @@ func (s *courseService) parseCourseTimes(times []string) ([]models.CourseTime, e
 }
 
 func (s *courseService) prepareCourse(dto dto.CreateCourseDTO) (*models.Course, error) {
-	if _, err := s.universityService.Get(dto.UniversityID); err != nil {
+	if _, err := s.universityService.Get(context.Background(), dto.UniversityID); err != nil {
 		return nil, err
 	}
 

--- a/api/services/faculty.go
+++ b/api/services/faculty.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"fmt"
 	"github.com/armanjr/termustat/api/dto"
 	"github.com/armanjr/termustat/api/errors"
@@ -39,7 +40,7 @@ func NewFacultyService(
 }
 
 func (s *facultyService) Create(dto dto.CreateFacultyDTO) (*dto.FacultyResponse, error) {
-	university, err := s.universityService.Get(dto.UniversityID)
+	university, err := s.universityService.Get(context.Background(), dto.UniversityID)
 	if err != nil {
 		switch {
 		case errors.Is(err, errors.ErrNotFound):
@@ -106,7 +107,7 @@ func (s *facultyService) Get(id uuid.UUID) (*dto.FacultyResponse, error) {
 }
 
 func (s *facultyService) GetAllByUniversity(universityID uuid.UUID) ([]*dto.FacultyResponse, error) {
-	_, err := s.universityService.Get(universityID)
+	_, err := s.universityService.Get(context.Background(), universityID)
 	if err != nil {
 		switch {
 		case errors.Is(err, errors.ErrNotFound):

--- a/api/services/professor.go
+++ b/api/services/professor.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"fmt"
 	"github.com/armanjr/termustat/api/dto"
 	"github.com/armanjr/termustat/api/errors"
@@ -97,7 +98,7 @@ func (s *professorService) Get(id uuid.UUID) (*dto.ProfessorDetailResponse, erro
 	}
 
 	// Get university details
-	university, err := s.universityService.Get(professor.UniversityID)
+	university, err := s.universityService.Get(context.Background(), professor.UniversityID)
 	if err != nil {
 		s.logger.Error("Failed to fetch university for professor",
 			zap.String("professor_id", id.String()),
@@ -119,7 +120,7 @@ func (s *professorService) Get(id uuid.UUID) (*dto.ProfessorDetailResponse, erro
 }
 
 func (s *professorService) GetOrCreateByName(universityID uuid.UUID, name string) (*dto.ProfessorMinimalResponse, error) {
-	university, err := s.universityService.Get(universityID)
+	university, err := s.universityService.Get(context.Background(), universityID)
 	if err != nil {
 		switch {
 		case errors.Is(err, errors.ErrNotFound):


### PR DESCRIPTION
(This PR is an experiment of using `google-labs-jules`)

This PR introduces `context.Context` to the university repository, service, and handler layers.

Key changes:
- University repository methods (`Create`, `Update`, `Find`, `FindAll`, `ExistsByName`, `Delete`) now accept and utilize `context.Context` for GORM operations.
- University service methods have been updated to accept and pass `context.Context` to the repository layer.
- University handler methods now create a `context.Context` with a 3-second timeout using `context.WithTimeout(c.Request.Context(), 3*time.Second)` and pass it to the service layer.
- Updated various service and test files that call university domain methods to pass an appropriate context (e.g., `context.Background()` in tests, or the existing request context in other services).
- Ensured all existing tests pass, and augmented `api/handlers/auth_test.go` to verify that the context passed to the mocked university service includes a deadline.