### PR TITLE
Fix: Handle string to time.Time conversion for CourseTime

### DIFF
--- a/api/models/course_time.go
+++ b/api/models/course_time.go
@@ -1,18 +1,79 @@
 package models
 
 import (
+	"database/sql/driver"
+	"fmt"
 	"github.com/google/uuid"
 	"time"
 )
 
 type CourseTime struct {
 	ID        uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
-	CourseID  uuid.UUID `gorm:"type:uuid;not null;index"`
-	DayOfWeek int       `gorm:"check:day_of_week BETWEEN 0 AND 6"`
-	StartTime time.Time `gorm:"type:time;not null"`
-	EndTime   time.Time `gorm:"type:time;not null"`
-	CreatedAt time.Time `gorm:"autoCreateTime"`
-	UpdatedAt time.Time `gorm:"autoUpdateTime"`
+	CourseID  uuid.UUID  `gorm:"type:uuid;not null;index"`
+	DayOfWeek int        `gorm:"check:day_of_week BETWEEN 0 AND 6"`
+	StartTime CustomTime `gorm:"type:time;not null"` // Changed from time.Time
+	EndTime   CustomTime `gorm:"type:time;not null"` // Changed from time.Time
+	CreatedAt time.Time  `gorm:"autoCreateTime"`
+	UpdatedAt time.Time  `gorm:"autoUpdateTime"`
+}
+
+// CustomTime handles parsing time from string values from the database
+type CustomTime struct {
+	Time  time.Time
+	Valid bool // Valid is true if Time is not NULL
+}
+
+// Scan implements the Scanner interface for CustomTime
+func (ct *CustomTime) Scan(value interface{}) error {
+	if value == nil {
+		ct.Time, ct.Valid = time.Time{}, false
+		return nil
+	}
+
+	switch v := value.(type) {
+	case time.Time:
+		ct.Time, ct.Valid = v, true
+		return nil
+	case []byte: // Handle byte slices (often returned by database drivers for strings)
+		s := string(v)
+		// Try parsing in HH:MM:SS format first
+		parsedTime, err := time.Parse("15:04:05", s)
+		if err != nil {
+			// If HH:MM:SS fails, try HH:MM
+			parsedTime, err = time.Parse("15:04", s)
+			if err != nil {
+				ct.Valid = false
+				return fmt.Errorf("CustomTime: unsupported type %T or format for value: %v", value, value)
+			}
+		}
+		ct.Time, ct.Valid = parsedTime, true
+		return nil
+	case string:
+		// Try parsing in HH:MM:SS format first
+		parsedTime, err := time.Parse("15:04:05", v)
+		if err != nil {
+			// If HH:MM:SS fails, try HH:MM
+			parsedTime, err = time.Parse("15:04", v)
+			if err != nil {
+				ct.Valid = false
+				return fmt.Errorf("CustomTime: unsupported type %T or format for value: %v", value, value)
+			}
+		}
+		ct.Time, ct.Valid = parsedTime, true
+		return nil
+	default:
+		ct.Valid = false
+		return fmt.Errorf("CustomTime: unsupported type %T for value: %v", value, value)
+	}
+}
+
+// Value implements the driver Valuer interface for CustomTime
+func (ct CustomTime) Value() (driver.Value, error) {
+	if !ct.Valid {
+		return nil, nil
+	}
+	// Return time in "HH:MM:SS" format, which is standard for SQL TIME type
+	return ct.Time.Format("15:04:05"), nil
 }
 
 func (CourseTime) TableName() string {

--- a/api/models/course_time_test.go
+++ b/api/models/course_time_test.go
@@ -1,0 +1,122 @@
+package models
+
+import (
+	"database/sql/driver"
+	"testing"
+	"time"
+)
+
+func TestCustomTime_Scan(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   interface{}
+		wantCt  CustomTime
+		wantErr bool
+	}{
+		{
+			name:  "scan nil",
+			value: nil,
+			wantCt: CustomTime{Time: time.Time{}, Valid: false},
+			wantErr: false,
+		},
+		{
+			name:  "scan time.Time",
+			value: time.Date(0, 1, 1, 10, 30, 0, 0, time.UTC),
+			wantCt: CustomTime{Time: time.Date(0, 1, 1, 10, 30, 0, 0, time.UTC), Valid: true},
+			wantErr: false,
+		},
+		{
+			name:  "scan string HH:MM:SS",
+			value: "14:45:30",
+			wantCt: CustomTime{Time: time.Date(0, 1, 1, 14, 45, 30, 0, time.UTC), Valid: true},
+			wantErr: false,
+		},
+		{
+			name:  "scan string HH:MM",
+			value: "09:15",
+			wantCt: CustomTime{Time: time.Date(0, 1, 1, 9, 15, 0, 0, time.UTC), Valid: true},
+			wantErr: false,
+		},
+		{
+			name:    "scan invalid string",
+			value:   "invalid-time",
+			wantCt:  CustomTime{Time: time.Time{}, Valid: false},
+			wantErr: true,
+		},
+		{
+			name:    "scan integer (unsupported)",
+			value:   12345,
+			wantCt:  CustomTime{Time: time.Time{}, Valid: false},
+			wantErr: true,
+		},
+		{
+			name:  "scan byte slice HH:MM:SS",
+			value: []byte("16:30:00"),
+			wantCt: CustomTime{Time: time.Date(0, 1, 1, 16, 30, 0, 0, time.UTC), Valid: true},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ct CustomTime
+			err := ct.Scan(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CustomTime.Scan() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			// For time comparison, ignore the location if not explicitly set in wantCt.Time for non-nil cases
+			if tt.wantCt.Valid && !ct.Time.Equal(tt.wantCt.Time) {
+                 // Re-parse to ensure consistent location for comparison if needed, or use specific parts
+                 expectedParsed, _ := time.Parse("15:04:05", tt.wantCt.Time.Format("15:04:05"))
+                 if !ct.Time.Equal(expectedParsed) {
+                    t.Errorf("CustomTime.Scan() gotTime = %v, want %v", ct.Time, tt.wantCt.Time)
+                 }
+			}
+            if ct.Valid != tt.wantCt.Valid {
+                 t.Errorf("CustomTime.Scan() gotValid = %v, want %v", ct.Valid, tt.wantCt.Valid)
+            }
+		})
+	}
+}
+
+func TestCustomTime_Value(t *testing.T) {
+	tests := []struct {
+		name    string
+		ct      CustomTime
+		wantVal driver.Value
+		wantErr bool
+	}{
+		{
+			name:    "value valid time",
+			ct:      CustomTime{Time: time.Date(0, 1, 1, 10, 30, 15, 0, time.UTC), Valid: true},
+			wantVal: "10:30:15",
+			wantErr: false,
+		},
+		{
+			name:    "value zero time but valid", // e.g. midnight
+			ct:      CustomTime{Time: time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			wantVal: "00:00:00",
+			wantErr: false,
+		},
+		{
+			name:    "value invalid time",
+			ct:      CustomTime{Time: time.Time{}, Valid: false},
+			wantVal: nil,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVal, err := tt.ct.Value()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CustomTime.Value() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotVal != tt.wantVal {
+				t.Errorf("CustomTime.Value() gotVal = %v, want %v", gotVal, tt.wantVal)
+			}
+		})
+	}
+}

--- a/api/services/course.go
+++ b/api/services/course.go
@@ -535,8 +535,8 @@ func (s *courseService) parseTimeSlot(timeStr string) (*models.CourseTime, error
 
 	return &models.CourseTime{
 		DayOfWeek: day,
-		StartTime: startTime,
-		EndTime:   endTime,
+		StartTime: models.CustomTime{Time: startTime, Valid: !startTime.IsZero()},
+		EndTime:   models.CustomTime{Time: endTime, Valid: !endTime.IsZero()},
 	}, nil
 }
 
@@ -647,12 +647,19 @@ func (s *courseService) CreateFromEngine(reqDto dto.CourseEngineDTO) (*dto.Cours
 }
 
 func mapCourseTimeToResponse(courseTime models.CourseTime) dto.CourseTimeResponse {
+	var startTime, endTime time.Time
+	if courseTime.StartTime.Valid {
+		startTime = courseTime.StartTime.Time
+	}
+	if courseTime.EndTime.Valid {
+		endTime = courseTime.EndTime.Time
+	}
 	return dto.CourseTimeResponse{
 		ID:        courseTime.ID,
 		CourseID:  courseTime.CourseID,
 		DayOfWeek: courseTime.DayOfWeek,
-		StartTime: courseTime.StartTime,
-		EndTime:   courseTime.EndTime,
+		StartTime: startTime,
+		EndTime:   endTime,
 	}
 }
 


### PR DESCRIPTION
[Created by Google Jules]

The API was encountering an "unsupported Scan, storing driver.Value type string into type *time.Time" error when fetching courses with their associated times. This indicated that the database was returning time values as strings, while GORM was expecting a type compatible with time.Time.

This commit addresses the issue by:
1. Defining a new type `CustomTime` in `api/models/course_time.go`.
2. Implementing the `sql.Scanner` interface for `CustomTime`. The `Scan` method parses time strings (formats "15:04:05" and "15:04") from the database into `time.Time`. It also correctly handles `nil` and actual `time.Time` values if provided by the driver.
3. Implementing the `driver.Valuer` interface for `CustomTime`. The `Value` method formats the `time.Time` as an "HH:MM:SS" string for database storage.
4. Updating the `CourseTime` model to use `CustomTime` for its `StartTime` and `EndTime` fields. The `gorm:"type:time"` tag is retained as the custom type now manages the specific conversion from the expected database string format.
5. Adding unit tests for the `Scan` and `Value` methods of `CustomTime` to ensure correctness of parsing and formatting logic. These tests cover various input scenarios, including valid and invalid time strings and nil values.

This change ensures that course times are correctly read from and written to the database, resolving the API error.