### PR TITLE
Frontend: Add Users admin page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Link, useLocation } from 'react-router-dom';
 import AppRoutes from './routes/index.js';
+import { SnackbarProvider } from './contexts/SnackbarContext.js';
 import { ThemeProvider } from '@mui/material';
 import muiTheme from './themes/muiTheme.js';
 
@@ -11,15 +12,17 @@ function App() {
 
   return (
     <ThemeProvider theme={muiTheme}>
-      {showNav && (
-        <nav>
-          <ul>
-            <li><Link to="/">Home</Link></li>
-            <li><Link to="/admin/login">Admin Login</Link></li>
-          </ul>
-        </nav>
-      )}
-      <AppRoutes />
+      <SnackbarProvider>
+        {showNav && (
+          <nav>
+            <ul>
+              <li><Link to="/">Home</Link></li>
+              <li><Link to="/admin/login">Admin Login</Link></li>
+            </ul>
+          </nav>
+        )}
+        <AppRoutes />
+      </SnackbarProvider>
     </ThemeProvider>
   );
 }

--- a/frontend/src/api/admin/faculties.js
+++ b/frontend/src/api/admin/faculties.js
@@ -29,3 +29,10 @@ export const editFaculty = async (id, facultyData) => {
   );
   return response;
 };
+
+export const getFacultyById = async (id) => {
+  const response = await axiosInstance.get(
+    `/admin/faculties/${id}`
+  );
+  return response;
+};

--- a/frontend/src/api/admin/universities.js
+++ b/frontend/src/api/admin/universities.js
@@ -29,3 +29,10 @@ export const editUniversity = async (id, universityData) => {
   );
   return response;
 };
+
+export const getUniversityById = async (id) => {
+  const response = await axiosInstance.get(
+    `/admin/universities/${id}`
+  );
+  return response;
+};

--- a/frontend/src/api/admin/users.js
+++ b/frontend/src/api/admin/users.js
@@ -1,0 +1,26 @@
+import axiosInstance from "../axiosInstance";
+
+export const getUsers = async (page = 1) => {
+  const response = await axiosInstance.get(
+    `/admin/users`,
+    {
+      params: { page },
+    }
+  );
+  return response;
+};
+
+export const deleteUser = async (id) => {
+  const response = await axiosInstance.delete(
+    `/admin/users/${id}`
+  );
+  return response;
+};
+
+export const editUser = async (id, userData) => {
+  const response = await axiosInstance.put(
+    `/admin/users/${id}`,
+    userData
+  );
+  return response;
+};

--- a/frontend/src/components/admin/EntityDialog.js
+++ b/frontend/src/components/admin/EntityDialog.js
@@ -49,6 +49,23 @@ const EntityDialog = ({
     });
   };
 
+  const handleSelectChange = (e, field) => {
+    const value = e.target.value;
+    setFormData((prev) => {
+      const hasFacultyField = fields.some((f) => f.name === "faculty_id");
+      return {
+        ...prev,
+        [field.name]: value,
+        ...(field.name === "university_id" && hasFacultyField
+          ? { faculty_id: "" }
+          : {}),
+      };
+    });
+    if (field.onChangeHandler) {
+      field.onChangeHandler(value);
+    }
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
 
@@ -129,6 +146,23 @@ const EntityDialog = ({
                       </div>
                     )}
                   </>
+                ) : field.inputType === "select" ? (
+                  <div key={field.name}>
+                    <select
+                      name={field.name}
+                      value={formData[field.name] || ""}
+                      onChange={(e) => handleSelectChange(e, field)}
+                    >
+                      <option key="" value="" disabled>
+                        {field.label}
+                      </option>
+                      {field.options?.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
                 ) : (
                   <></>
                 )
@@ -144,6 +178,8 @@ const EntityDialog = ({
                       ? formData.name_fa
                       : entityName === "نیمسال تحصیلی"
                       ? `${formData.term} ${formData.year}`
+                      : entityName === "کاربر"
+                      ? `${formData.first_name} ${formData.last_name}`
                       : ""}
                     "&nbsp;
                   </span>

--- a/frontend/src/components/admin/EntityDialog.js
+++ b/frontend/src/components/admin/EntityDialog.js
@@ -2,7 +2,8 @@ import { useState, useEffect } from "react";
 import styles from "./EntityDialog.module.css";
 import Input from "../form/Input";
 import Button from "../form/Button";
-import { Dialog, DialogContent, Snackbar, Alert } from "@mui/material";
+import { Dialog, DialogContent } from "@mui/material";
+import { useSnackbar } from "../../contexts/SnackbarContext";
 
 const EntityDialog = ({
   open,
@@ -14,6 +15,7 @@ const EntityDialog = ({
   onSubmit,
   onClose,
 }) => {
+  const { showSnackbar } = useSnackbar();
   const modeLabels = { add: "افزودن", edit: "ویرایش", delete: "حذف" };
   const [formData, setFormData] = useState({});
   const [errors, setErrors] = useState({});
@@ -87,16 +89,6 @@ const EntityDialog = ({
       else
         showSnackbar(`خطا در ${modeLabels[mode]} ${entityName}. لطفا دوباره تلاش کنید.`, "error");
     }
-  };
-
-  const [snackbar, setSnackbar] = useState({
-    open: false,
-    message: "",
-    severity: "success",
-  });
-
-  const showSnackbar = (message, severity = "success") => {
-    setSnackbar({ open: true, message, severity });
   };
 
   return (
@@ -193,18 +185,6 @@ const EntityDialog = ({
           </form>
         </DialogContent>
       </Dialog>
-
-      <Snackbar
-        open={snackbar.open}
-        onClose={() => setSnackbar({ ...snackbar, open: false })}
-      >
-        <Alert
-          onClose={() => setSnackbar({ ...snackbar, open: false })}
-          severity={snackbar.severity}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
     </>
   );
 };

--- a/frontend/src/components/admin/EntityDialog.js
+++ b/frontend/src/components/admin/EntityDialog.js
@@ -139,7 +139,7 @@ const EntityDialog = ({
                       value={formData[field.name] || ""}
                       onChange={handleChange}
                       dir={field.dir || ""}
-                      required={field.required !== undefined ? field.required : true}
+                      required={field.required ?? true}
                     />
                     {errors[field.name] && (
                       <div className={styles.errorMessage}>

--- a/frontend/src/components/admin/EntityDialog.js
+++ b/frontend/src/components/admin/EntityDialog.js
@@ -129,6 +129,7 @@ const EntityDialog = ({
                     ))}
                   </div>
                 ) : field.inputType === "text" ||
+                  field.inputType === "password" ||
                   field.inputType === "number" ? (
                   <>
                     <Input
@@ -138,7 +139,7 @@ const EntityDialog = ({
                       value={formData[field.name] || ""}
                       onChange={handleChange}
                       dir={field.dir || ""}
-                      required
+                      required={field.required !== undefined ? field.required : true}
                     />
                     {errors[field.name] && (
                       <div className={styles.errorMessage}>

--- a/frontend/src/components/admin/EntityHeader.js
+++ b/frontend/src/components/admin/EntityHeader.js
@@ -6,11 +6,13 @@ const EntityHeader = ({ title, entityName, onAdd }) => {
   return (
     <div className={styles.top}>
       <h1>{title}</h1>
-      <Tooltip title={`افزودن ${entityName}`} placement="right" arrow>
-        <IconButton variant="addButton" onClick={onAdd}>
-          <Add />
-        </IconButton>
-      </Tooltip>
+      {onAdd && (
+        <Tooltip title={`افزودن ${entityName}`} placement="right" arrow>
+          <IconButton variant="addButton" onClick={onAdd}>
+            <Add />
+          </IconButton>
+        </Tooltip>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/admin/EntityPage.js
+++ b/frontend/src/components/admin/EntityPage.js
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import useFetch from "../../hooks/useFetch";
 import EntityHeader from "./EntityHeader";
 import EntityTable from "./EntityTable";
 import EntityDialog from "./EntityDialog";
@@ -7,7 +6,8 @@ import EntityDialog from "./EntityDialog";
 const EntityPage = ({
   title,
   entityName,
-  fetchFunction,
+  data,
+  fetchData,
   tableColumns,
   dialogFields,
   validate,
@@ -16,8 +16,6 @@ const EntityPage = ({
   canEdit=true,
   canDelete=true,
 }) => {
-  const { data, loading, error, fetchData } = useFetch(fetchFunction);
-
   const [dialogState, setDialogState] = useState({
     open: false,
     mode: null,
@@ -47,18 +45,12 @@ const EntityPage = ({
         entityName={entityName}
         onAdd={canAdd ? () => openDialog("add") : null}
       />
-      {loading ? (
-        <p></p>
-      ) : error ? (
-        <p>{error}</p>
-      ) : (
-        <EntityTable
-          data={data}
-          columns={tableColumns}
-          onEdit={canEdit ? (item) => openDialog("edit", item) : null}
-          onDelete={canEdit ? (item) => openDialog("delete", item) : null}
-        />
-      )}
+      <EntityTable
+        data={data}
+        columns={tableColumns}
+        onEdit={canEdit ? (item) => openDialog("edit", item) : null}
+        onDelete={canEdit ? (item) => openDialog("delete", item) : null}
+      />
       {(canAdd || canEdit || canDelete) && (
         <EntityDialog
           open={dialogState.open}

--- a/frontend/src/components/admin/EntityPage.js
+++ b/frontend/src/components/admin/EntityPage.js
@@ -12,6 +12,7 @@ const EntityPage = ({
   dialogFields,
   validate,
   onSubmit,
+  onOpenDialog,
   canAdd=true,
   canEdit=true,
   canDelete=true,
@@ -22,7 +23,18 @@ const EntityPage = ({
     entity: null,
   });
 
-  const openDialog = (mode, entity = null) => {
+  const [localDialogFields, setLocalDialogFields] = useState(dialogFields);
+
+  const openDialog = async (mode, entity = null) => {
+    if (onOpenDialog) {
+      await onOpenDialog({
+        mode,
+        entity,
+        setDialogFields: setLocalDialogFields,
+      });
+    } else {
+      setLocalDialogFields(dialogFields);
+    }
     setDialogState({ open: true, mode, entity });
   };
 
@@ -57,7 +69,7 @@ const EntityPage = ({
           mode={dialogState.mode}
           entityName={entityName}
           entity={dialogState.entity}
-          fields={dialogFields}
+          fields={localDialogFields}
           validate={validate}
           onSubmit={handleSubmit}
           onClose={closeDialog}

--- a/frontend/src/components/admin/EntityPage.js
+++ b/frontend/src/components/admin/EntityPage.js
@@ -12,6 +12,9 @@ const EntityPage = ({
   dialogFields,
   validate,
   onSubmit,
+  canAdd=true,
+  canEdit=true,
+  canDelete=true,
 }) => {
   const { data, loading, error, fetchData } = useFetch(fetchFunction);
 
@@ -42,7 +45,7 @@ const EntityPage = ({
       <EntityHeader
         title={title}
         entityName={entityName}
-        onAdd={() => openDialog("add")}
+        onAdd={canAdd ? () => openDialog("add") : null}
       />
       {loading ? (
         <p></p>
@@ -52,20 +55,22 @@ const EntityPage = ({
         <EntityTable
           data={data}
           columns={tableColumns}
-          onEdit={(item) => openDialog("edit", item)}
-          onDelete={(item) => openDialog("delete", item)}
+          onEdit={canEdit ? (item) => openDialog("edit", item) : null}
+          onDelete={canEdit ? (item) => openDialog("delete", item) : null}
         />
       )}
-      <EntityDialog
-        open={dialogState.open}
-        mode={dialogState.mode}
-        entityName={entityName}
-        entity={dialogState.entity}
-        fields={dialogFields}
-        validate={validate}
-        onSubmit={handleSubmit}
-        onClose={closeDialog}
-      />
+      {(canAdd || canEdit || canDelete) && (
+        <EntityDialog
+          open={dialogState.open}
+          mode={dialogState.mode}
+          entityName={entityName}
+          entity={dialogState.entity}
+          fields={dialogFields}
+          validate={validate}
+          onSubmit={handleSubmit}
+          onClose={closeDialog}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/admin/EntityPage.js
+++ b/frontend/src/components/admin/EntityPage.js
@@ -61,7 +61,7 @@ const EntityPage = ({
         data={data}
         columns={tableColumns}
         onEdit={canEdit ? (item) => openDialog("edit", item) : null}
-        onDelete={canEdit ? (item) => openDialog("delete", item) : null}
+        onDelete={canDelete ? (item) => openDialog("delete", item) : null}
       />
       {(canAdd || canEdit || canDelete) && (
         <EntityDialog

--- a/frontend/src/contexts/SnackbarContext.js
+++ b/frontend/src/contexts/SnackbarContext.js
@@ -1,0 +1,36 @@
+import { createContext, useContext, useState } from "react";
+import { Snackbar, Alert } from "@mui/material";
+
+const SnackbarContext = createContext();
+
+export const useSnackbar = () => useContext(SnackbarContext);
+
+export const SnackbarProvider = ({ children }) => {
+  const [message, setMessage] = useState(null);
+  const [severity, setSeverity] = useState("success");
+
+  const showSnackbar = (msg, sev = "success") => {
+    setMessage(msg);
+    setSeverity(sev);
+  };
+
+  const hideSnackbar = () => {
+    setMessage(null);
+  };
+
+  return (
+    <SnackbarContext.Provider value={{ showSnackbar, hideSnackbar }}>
+      {children}
+      {message && (
+        <Snackbar
+          open={Boolean(message)}
+          onClose={hideSnackbar}
+        >
+          <Alert onClose={hideSnackbar} severity={severity}>
+            {message}
+          </Alert>
+        </Snackbar>
+      )}
+    </SnackbarContext.Provider>
+  );
+};

--- a/frontend/src/hooks/useFetch.js
+++ b/frontend/src/hooks/useFetch.js
@@ -1,7 +1,6 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 
 const useFetch = (fetchFunction, id = null) => {
-  const hasFetched = useRef(false);
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -30,10 +29,8 @@ const useFetch = (fetchFunction, id = null) => {
   };
 
   useEffect(() => {
-    if (hasFetched.current) return;
-    hasFetched.current = true;
     fetch();
-  }, [fetchFunction, id]);
+  }, []);
 
   return { data, loading, error, fetchData: fetch };
 };

--- a/frontend/src/hooks/useFetch.js
+++ b/frontend/src/hooks/useFetch.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 
-const useFetch = (fetchFunction, id = null) => {
+const useFetch = (fetchFunction, deps = null) => {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -10,12 +10,7 @@ const useFetch = (fetchFunction, id = null) => {
     setError(null);
 
     try {
-      let response;
-      if (id) {
-        response = await fetchFunction(id);
-      } else {
-        response = await fetchFunction();
-      }
+      const response = await fetchFunction();
       setData(response.data);
     } catch (error) {
       if (error.response?.status === 500) {
@@ -30,7 +25,7 @@ const useFetch = (fetchFunction, id = null) => {
 
   useEffect(() => {
     fetch();
-  }, []);
+  }, deps === null ? [] : deps);
 
   return { data, loading, error, fetchData: fetch };
 };

--- a/frontend/src/layouts/AdminLayout.js
+++ b/frontend/src/layouts/AdminLayout.js
@@ -22,6 +22,7 @@ import {
   Business,
   CalendarMonth,
   PeopleAlt,
+  AccountCircle,
   Menu,
   ExitToApp,
 } from "@mui/icons-material";
@@ -32,6 +33,7 @@ const menuItems = [
   { label: "دانشکده‌ها", icon: <Business />, route: "/admin/faculties" },
   { label: "نیمسال تحصیلی", icon: <CalendarMonth />, route: "/admin/semesters" },
   { label: "اساتید", icon: <PeopleAlt />, route: "/admin/professors" },
+  { label: "کاربران", icon: <AccountCircle />, route: "/admin/users" },
 ];
 
 export default function AdminLayout() {

--- a/frontend/src/pages/admin/faculties/Faculties.js
+++ b/frontend/src/pages/admin/faculties/Faculties.js
@@ -45,7 +45,8 @@ const Faculties = () => {
           key={selectedUniversity}
           title={`دانشکده‌های ${ universities?.find((u) => u.id === selectedUniversity)?.name_fa || "" }`}
           entityName={config.entityName}
-          fetchFunction={() => config.fetchFunction(selectedUniversity)}
+          data={faculties}
+          fetchData={fetchData}
           tableColumns={config.tableColumns}
           dialogFields={config.dialogFields}
           validate={config.validate}

--- a/frontend/src/pages/admin/faculties/config.js
+++ b/frontend/src/pages/admin/faculties/config.js
@@ -2,7 +2,6 @@ import {
   addFaculty,
   editFaculty,
   deleteFaculty,
-  getFaculties,
 } from "../../../api/admin/faculties";
 
 import { IconButton } from "@mui/material";
@@ -11,7 +10,6 @@ import { Block } from "@mui/icons-material";
 const config = {
   title: "",
   entityName: "دانشکده",
-  fetchFunction: getFaculties,
 
   tableColumns: [
     {

--- a/frontend/src/pages/admin/semesters/Semesters.js
+++ b/frontend/src/pages/admin/semesters/Semesters.js
@@ -1,12 +1,20 @@
 import EntityPage from "../../../components/admin/EntityPage";
 import config from "./config";
+import useFetch from "../../../hooks/useFetch";
+import { getSemesters } from "../../../api/admin/semesters";
 
 const Semesters = () => {
+  const { data, loading, error, fetchData } = useFetch(getSemesters);
+
+  if (loading) return <></>;
+  if (error) return <div>{error}</div>;
+
   return (
     <EntityPage
       title={config.title}
       entityName={config.entityName}
-      fetchFunction={config.fetchFunction}
+      data={data}
+      fetchData={fetchData}
       tableColumns={config.tableColumns}
       dialogFields={config.dialogFields}
       onSubmit={config.onSubmit}

--- a/frontend/src/pages/admin/semesters/config.js
+++ b/frontend/src/pages/admin/semesters/config.js
@@ -2,13 +2,11 @@ import {
   addSemester,
   editSemester,
   deleteSemester,
-  getSemesters,
 } from "../../../api/admin/semesters";
 
 const config = {
   title: "نیمسال تحصیلی",
   entityName: "نیمسال تحصیلی",
-  fetchFunction: getSemesters,
 
   tableColumns: [
     {

--- a/frontend/src/pages/admin/universities/Universities.js
+++ b/frontend/src/pages/admin/universities/Universities.js
@@ -1,12 +1,20 @@
 import EntityPage from "../../../components/admin/EntityPage";
 import config from "./config";
+import useFetch from "../../../hooks/useFetch";
+import { getUniversities } from "../../../api/admin/universities";
 
 const Universities = () => {
+  const { data, loading, error, fetchData } = useFetch(getUniversities);
+
+  if (loading) return <></>;
+  if (error) return <div>{error}</div>;
+
   return (
     <EntityPage
       title={config.title}
       entityName={config.entityName}
-      fetchFunction={config.fetchFunction}
+      data={data}
+      fetchData={fetchData}
       tableColumns={config.tableColumns}
       dialogFields={config.dialogFields}
       validate={config.validate}

--- a/frontend/src/pages/admin/universities/config.js
+++ b/frontend/src/pages/admin/universities/config.js
@@ -2,7 +2,6 @@ import {
   addUniversity,
   editUniversity,
   deleteUniversity,
-  getUniversities,
 } from "../../../api/admin/universities";
 
 import { IconButton } from "@mui/material";
@@ -11,7 +10,6 @@ import { Block } from "@mui/icons-material";
 const config = {
   title: "دانشگاه‌ها",
   entityName: "دانشگاه",
-  fetchFunction: getUniversities,
 
   tableColumns: [
     {

--- a/frontend/src/pages/admin/users/Users.js
+++ b/frontend/src/pages/admin/users/Users.js
@@ -25,7 +25,8 @@ const enhanceUsersWithNames = async (users) => {
       try {
         const res = await getFacultyById(id);
         facultyCache.set(id, res.data.name_fa);
-      } catch {
+      } catch(err) {
+        console.error(`Failed to fetch faculty with ID ${id}:`, err);
         facultyCache.set(id, "نامشخص");
       }
     });
@@ -35,7 +36,8 @@ const enhanceUsersWithNames = async (users) => {
       try {
         const res = await getUniversityById(id);
         universityCache.set(id, res.data.name_fa);
-      } catch {
+      } catch(err) {
+        console.error(`Failed to fetch university with ID ${id}:`, err);
         universityCache.set(id, "نامشخص");
       }
     });

--- a/frontend/src/pages/admin/users/Users.js
+++ b/frontend/src/pages/admin/users/Users.js
@@ -1,0 +1,100 @@
+import { useState, useEffect } from "react";
+import styles from "./Users.module.css";
+import EntityPage from "../../../components/admin/EntityPage";
+import config from "./config";
+import useFetch from "../../../hooks/useFetch";
+import { getUsers } from "../../../api/admin/users";
+import { getUniversityById } from "../../../api/admin/universities";
+import { getFacultyById } from "../../../api/admin/faculties";
+import { useSearchParams } from "react-router-dom";
+import { Pagination } from "@mui/material";
+
+const enhanceUsersWithNames = async (users) => {
+  const enhancedUsers = await Promise.all(
+    users.map(async (user) => {
+      let faculty_name = "نامشخص";
+      let university_name = "نامشخص";
+      if (user.faculty_id) {
+        try {
+          const res = await getFacultyById(user.faculty_id);
+          faculty_name = res.data.name_fa;
+        } catch {
+          faculty_name = "نامشخص";
+        }
+      }
+      if (user.university_id) {
+        try {
+          const res = await getUniversityById(user.university_id);
+          university_name = res.data.name_fa;
+        } catch {
+          university_name = "نامشخص";
+        }
+      }
+      return {
+        ...user,
+        faculty_name,
+        university_name,
+      };
+    })
+  );
+  return enhancedUsers;
+};
+
+const Users = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const page = parseInt(searchParams.get("page")) || 1;
+
+  const handlePageChange = (event, value) => {
+    setSearchParams({ page: value });
+  };
+
+  const { data, loading, error, fetchData } = useFetch(() => getUsers(page), [page]);
+  let users = data?.items;
+
+  const [enhancedUsers, setEnhancedUsers] = useState([]);
+  const [enhancing, setEnhancing] = useState(true);
+
+  useEffect(() => {
+    if (users) {
+      if (users.length === 0) {
+        setEnhancedUsers([]);
+        setEnhancing(false);
+      } else {
+        setEnhancing(true);
+        enhanceUsersWithNames(users).then((result) => {
+          setEnhancedUsers(result);
+          setEnhancing(false);
+        });
+      }
+    }
+  }, [users]);
+
+  if (loading || enhancing) return <></>;
+  if (error) return <div>{error}</div>;
+
+  return (
+    <>
+      <EntityPage
+        key={page}
+        title={config.title}
+        entityName={config.entityName}
+        data={enhancedUsers}
+        fetchData={fetchData}
+        tableColumns={config.tableColumns}
+        dialogFields={config.dialogFields}
+        onSubmit={config.onSubmit}
+        onOpenDialog={config.onOpenDialog}
+        canAdd={false}
+      />
+      <div className={styles.pagination}>
+        <Pagination
+          count={Math.ceil(data.total / data.limit)}
+          page={page}
+          onChange={handlePageChange}
+        />
+      </div>
+    </>
+  );
+};
+
+export default Users;

--- a/frontend/src/pages/admin/users/Users.module.css
+++ b/frontend/src/pages/admin/users/Users.module.css
@@ -1,0 +1,4 @@
+.pagination {
+  display: flex;
+  justify-content: center;
+}

--- a/frontend/src/pages/admin/users/Users.module.css
+++ b/frontend/src/pages/admin/users/Users.module.css
@@ -2,3 +2,12 @@
   display: flex;
   justify-content: center;
 }
+
+.email {
+  display: inline-flex;
+  align-items: center;
+}
+
+.admin {
+  text-align: center;
+}

--- a/frontend/src/pages/admin/users/config.js
+++ b/frontend/src/pages/admin/users/config.js
@@ -1,6 +1,9 @@
+import styles from "./Users.module.css";
 import { editUser, deleteUser } from "../../../api/admin/users";
 import { getFaculties } from "../../../api/admin/faculties";
 import { getUniversities } from "../../../api/admin/universities";
+import { IconButton } from "@mui/material";
+import { Error } from '@mui/icons-material';
 
 const universityListCache = { data: null, fetched: false };
 const facultyListCache = new Map();
@@ -56,28 +59,8 @@ const config = {
       render: (user) => user.last_name,
     },
     {
-      key: "email",
-      render: (user) => user.email,
-      hideOnTablet: true,
-    },
-    {
-      key: "email_verified",
-      render: (user) => String(user.email_verified),
-      hideOnTablet: true,
-    },
-    {
       key: "gender",
-      render: (user) => user.gender,
-      hideOnTablet: true,
-    },
-    {
-      key: "is_admin",
-      render: (user) => String(user.is_admin),
-      hideOnTablet: true,
-    },
-    {
-      key: "student_id",
-      render: (user) => user.student_id,
+      render: (user) => (user.gender === "female" ? "زن" : "مرد"),
       hideOnTablet: true,
     },
     {
@@ -88,6 +71,34 @@ const config = {
     {
       key: "faculty_name",
       render: (user) => user.faculty_name,
+      hideOnTablet: true,
+    },
+    {
+      key: "student_id",
+      render: (user) => user.student_id,
+      hideOnTablet: true,
+    },
+    {
+      key: "email",
+      render: (user) => (
+        <div  className={styles.email}>
+          {user.email}
+          {!user.email_verified && (
+            <IconButton disabled>
+              <Error />
+            </IconButton>
+          )}
+        </div>
+      ),
+      hideOnTablet: true,
+    },
+    {
+      key: "is_admin",
+      render: (user) => (
+        <div className={styles.admin}>
+          {user.is_admin ? "ادمین" : ""}
+        </div>
+      ),
       hideOnTablet: true,
     },
   ],

--- a/frontend/src/pages/admin/users/config.js
+++ b/frontend/src/pages/admin/users/config.js
@@ -131,6 +131,15 @@ const config = {
       inputType: "select",
       options: [],
     },
+    {
+      name: "password",
+      label: "رمز عبور جدید (اختیاری)",
+      dir: "ltr",
+      defaultValue: "",
+      dataType: "string",
+      inputType: "password",
+      required: false,
+    },
   ],
 
   onSubmit: async ({ id, data, mode }) => {

--- a/frontend/src/pages/admin/users/config.js
+++ b/frontend/src/pages/admin/users/config.js
@@ -1,0 +1,175 @@
+import { editUser, deleteUser } from "../../../api/admin/users";
+import { getFaculties } from "../../../api/admin/faculties";
+import { getUniversities } from "../../../api/admin/universities";
+
+const config = {
+  title: "کاربران",
+  entityName: "کاربر",
+
+  tableColumns: [
+    {
+      key: "first_name",
+      render: (user) => user.first_name,
+    },
+    {
+      key: "last_name",
+      render: (user) => user.last_name,
+    },
+    {
+      key: "email",
+      render: (user) => user.email,
+      hideOnTablet: true,
+    },
+    {
+      key: "email_verified",
+      render: (user) => user.email_verified + "",
+      hideOnTablet: true,
+    },
+    {
+      key: "gender",
+      render: (user) => user.gender,
+      hideOnTablet: true,
+    },
+    {
+      key: "is_admin",
+      render: (user) => user.is_admin + "",
+      hideOnTablet: true,
+    },
+    {
+      key: "student_id",
+      render: (user) => user.student_id,
+      hideOnTablet: true,
+    },
+    {
+      key: "university_name",
+      render: (user) => user.university_name,
+      hideOnTablet: true,
+    },
+    {
+      key: "faculty_name",
+      render: (user) => user.faculty_name,
+      hideOnTablet: true,
+    },
+  ],
+
+  dialogFields: [
+    {
+      name: "first_name",
+      label: "نام",
+      defaultValue: "",
+      dataType: "string",
+      inputType: "text",
+    },
+    {
+      name: "last_name",
+      label: "نام خانوادگی",
+      defaultValue: "",
+      dataType: "string",
+      inputType: "text",
+    },
+    {
+      name: "gender",
+      defaultValue: "female",
+      dataType: "string",
+      inputType: "radio",
+      options: [
+        { label: "زن", value: "female" },
+        { label: "مرد", value: "male" },
+      ],
+    },
+    {
+      name: "university_id",
+      label: "دانشگاه",
+      defaultValue: "",
+      dataType: "string",
+      inputType: "select",
+      options: [],
+    },
+    {
+      name: "faculty_id",
+      label: "دانشکده",
+      defaultValue: "",
+      dataType: "string",
+      inputType: "select",
+      options: [],
+    },
+  ],
+
+  onSubmit: async ({ id, data, mode }) => {
+    if (mode === "edit") await editUser(id, data);
+    if (mode === "delete") await deleteUser(id);
+  },
+
+  onOpenDialog: async ({ mode, entity, setDialogFields }) => {
+    try {
+      let universityOptions = [];
+      let facultyOptions = [];
+      if (mode === "edit") {
+        const universityRes = await getUniversities();
+        universityOptions = universityRes?.data || [];
+        if (entity?.university_id) {
+          const facultyRes = await getFaculties(entity.university_id);
+          facultyOptions = facultyRes?.data || [];
+        }
+      }
+      const handleUniversityChange = async (universityId) => {
+        setDialogFields((prev) =>
+          prev.map((field) =>
+            field.name === "faculty_id" ? { ...field, options: [] } : field
+          )
+        );
+        if (universityId) {
+          const facultyRes = await getFaculties(universityId);
+          const newFacultyOptions = facultyRes?.data || [];
+          setDialogFields((prev) =>
+            prev.map((field) =>
+              field.name === "faculty_id"
+                ? {
+                    ...field,
+                    options: newFacultyOptions.map((f) => ({
+                      label: f.name_fa,
+                      value: f.id,
+                    })),
+                  }
+                : field
+            )
+          );
+        }
+      };
+      setDialogFields((prevFields) =>
+        prevFields.map((field) => {
+          if (field.name === "university_id") {
+            return {
+              ...field,
+              options: universityOptions.map((u) => ({
+                label: u.name_fa,
+                value: u.id,
+              })),
+              onChangeHandler: handleUniversityChange,
+            };
+          }
+          if (field.name === "faculty_id") {
+            return {
+              ...field,
+              options: facultyOptions.map((f) => ({
+                label: f.name_fa,
+                value: f.id,
+              })),
+            };
+          }
+          return field;
+        })
+      );
+    } catch {
+      setDialogFields((prevFields) =>
+        prevFields.map((field) =>
+          field.name === "university_id" || field.name === "faculty_id"
+            ? { ...field, options: [] }
+            : field
+        )
+      );
+    }
+  },
+};
+
+export default config;

--- a/frontend/src/pages/admin/users/config.js
+++ b/frontend/src/pages/admin/users/config.js
@@ -18,7 +18,8 @@ const getCachedUniversities = async () => {
     universityListCache.data = options;
     universityListCache.fetched = true;
     return options;
-  } catch {
+  } catch(err) {
+    console.error("Failed to fetch universities:", err);
     return [];
   }
 };
@@ -35,7 +36,8 @@ const getCachedFaculties = async (universityId) => {
     }));
     facultyListCache.set(universityId, options);
     return options;
-  } catch {
+  } catch(err) {
+    console.error(`Failed to fetch faculties for university ID ${universityId}:`, err);
     return [];
   }
 };
@@ -60,7 +62,7 @@ const config = {
     },
     {
       key: "email_verified",
-      render: (user) => user.email_verified + "",
+      render: (user) => String(user.email_verified),
       hideOnTablet: true,
     },
     {
@@ -70,7 +72,7 @@ const config = {
     },
     {
       key: "is_admin",
-      render: (user) => user.is_admin + "",
+      render: (user) => String(user.is_admin),
       hideOnTablet: true,
     },
     {
@@ -195,7 +197,8 @@ const config = {
           return field;
         })
       );
-    } catch {
+    } catch(err) {
+      console.error("Failed to open dialog and set fields:", err);
       setDialogFields((prevFields) =>
         prevFields.map((field) =>
           field.name === "university_id" || field.name === "faculty_id"

--- a/frontend/src/routes/index.js
+++ b/frontend/src/routes/index.js
@@ -10,6 +10,7 @@ import Universities from '../pages/admin/universities/Universities';
 import Faculties from '../pages/admin/faculties/Faculties';
 import Semesters from '../pages/admin/semesters/Semesters';
 import Professors from '../pages/admin/professors/Professors';
+import Users from '../pages/admin/users/Users';
 
 const Home = () => <div>Home</div>;
 
@@ -38,6 +39,7 @@ function AppRoutes() {
             <Route path="faculties" element={<Faculties />} />
             <Route path="semesters" element={<Semesters />} />
             <Route path="professors" element={<Professors />} />
+            <Route path="users" element={<Users />} />
           </Route>
         </Route>
       </Routes>

--- a/frontend/src/themes/muiTheme.js
+++ b/frontend/src/themes/muiTheme.js
@@ -75,6 +75,23 @@ const muiTheme = createTheme({
         },
       },
     },
+    MuiPagination: {
+      styleOverrides: {
+        root: {
+          direction: 'ltr',
+        },
+      },
+    },
+    MuiPaginationItem: {
+      styleOverrides: {
+        root: {
+          "&.Mui-selected": {
+            backgroundColor: "#309a9a",
+            color: "#ffffff",
+          },
+        },
+      },
+    },
   },
 });
 


### PR DESCRIPTION
**Note**: This PR depends on `refactor/useFetch` (https://github.com/ArmanJR/termustat/pull/38) being merged into main first.

Added Users admin page with the following updates:

- Updated EntityPage: Added the onOpenDialog prop to support more complex dialog handling, such as dynamically updating select options based on selected values.
- Implemented caching to reduce API requests.