### PR TITLE
Frontend: Fix routing issues without Strict Mode

### DIFF
--- a/frontend/src/routes/AdminRoute.js
+++ b/frontend/src/routes/AdminRoute.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import { Navigate, Outlet } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 
@@ -7,15 +7,10 @@ import { useAuth } from "../contexts/AuthContext";
  * Checks if the user is logged in and has admin privileges.
  */
 const AdminRoute = () => {
-  const isFirstRender = useRef(true);
   const { isAdmin, isLoggingOut, isLoggedIn, tryRefreshToken } = useAuth();
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return; // Skip the effect on first render (loading state)
-    }
     const refreshToken = async () => {
       await tryRefreshToken();
       setLoading(false);

--- a/frontend/src/routes/AuthRedirect.js
+++ b/frontend/src/routes/AuthRedirect.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 
@@ -7,15 +7,10 @@ import { useAuth } from "../contexts/AuthContext";
  * Redirects authenticated users away from some public pages if needed (e.g., login).
  */
 const AuthRedirect = ({ children, redirectTo }) => {
-  const isFirstRender = useRef(true);
   const { tryRefreshToken, isLoggedIn } = useAuth();
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return; // Skip the effect on first render (loading state)
-    }
     const refreshToken = async () => {
       await tryRefreshToken();
       setLoading(false);


### PR DESCRIPTION
Fixed the behavior of AuthRedirect and AdminRoute when React Strict Mode is disabled by removing the first render check. In development, React Strict Mode causes two API requests which hid the issue, but in production, only one request is made, which would cause routing to fail.