### PR TITLE
Fix misplaced password reset helper

### DIFF
--- a/api/services/admin_user.go
+++ b/api/services/admin_user.go
@@ -275,32 +275,6 @@ func (s *adminUserService) GetByFaculty(ctx context.Context, facultyID uuid.UUID
 	}, nil
 }
 
-func (s *authService) sendPasswordResetEmail(user *models.User, token string) error {
-	resetURL := fmt.Sprintf("%s/reset-password?token=%s", s.frontendURL, token)
-	tplData := struct {
-		ResetURL string
-	}{ResetURL: resetURL}
-
-	emailContent, err := s.mailer.RenderTemplate("password_reset_email.html", tplData)
-	if err != nil {
-		s.logger.Error("Failed to render password reset email template",
-			zap.String("user_id", user.ID.String()),
-			zap.String("operation", "sendPasswordResetEmail"),
-			zap.Error(err))
-		return fmt.Errorf("failed to render password reset email template: %w", err)
-	}
-
-	if err = s.mailer.SendEmail(user.Email, emailContent.Subject, emailContent.Body); err != nil {
-		s.logger.Error("Failed to send password reset email",
-			zap.String("user_id", user.ID.String()),
-			zap.String("operation", "sendPasswordResetEmail"),
-			zap.Error(err))
-		return fmt.Errorf("failed to send password reset email: %w", err)
-	}
-
-	return nil
-}
-
 func (s *adminUserService) mapUserToDTO(user *models.User) (*dto.AdminUserResponse, error) {
 	return &dto.AdminUserResponse{
 		ID:            user.ID,

--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"context"
 	"crypto/rand"
 	"encoding/base64"

--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -334,6 +334,32 @@ func (s *authService) Logout(ctx context.Context, refreshToken string) error {
 	return s.refreshRepo.Revoke(rt.ID)
 }
 
+func (s *authService) sendPasswordResetEmail(user *models.User, token string) error {
+	resetURL := fmt.Sprintf("%s/reset-password?token=%s", s.frontendURL, token)
+	tplData := struct {
+		ResetURL string
+	}{ResetURL: resetURL}
+
+	emailContent, err := s.mailer.RenderTemplate("password_reset_email.html", tplData)
+	if err != nil {
+		s.logger.Error("Failed to render password reset email template",
+			zap.String("user_id", user.ID.String()),
+			zap.String("operation", "sendPasswordResetEmail"),
+			zap.Error(err))
+		return fmt.Errorf("failed to render password reset email template: %w", err)
+	}
+
+	if err = s.mailer.SendEmail(user.Email, emailContent.Subject, emailContent.Body); err != nil {
+		s.logger.Error("Failed to send password reset email",
+			zap.String("user_id", user.ID.String()),
+			zap.String("operation", "sendPasswordResetEmail"),
+			zap.Error(err))
+		return fmt.Errorf("failed to send password reset email: %w", err)
+	}
+
+	return nil
+}
+
 // Helpers
 const refreshByteLen = 64
 


### PR DESCRIPTION
[Created by ChatGPT Codex]

## Summary
- move sendPasswordResetEmail helper from admin_user.go into auth.go

## Testing
- `go vet ./...` *(fails: Forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_683f5b030bc48327940d46e9e9a868ee